### PR TITLE
USRPs with 4 channels (e.g., N310)

### DIFF
--- a/CC/Sounder/files/usrp-bs-only.json
+++ b/CC/Sounder/files/usrp-bs-only.json
@@ -8,7 +8,7 @@
 		 "txgainA" : 15,
 		 "rxgainB" : 20,
 		 "txgainB" : 15,
-		 "rate" : 50e6,
+		 "rate" : 20e6,
 		 "frame_schedule" : [
 		     "BGPGGGGGGGGGGGGGGGGG"
 		 ],

--- a/CC/Sounder/files/usrp-client-only.json
+++ b/CC/Sounder/files/usrp-client-only.json
@@ -18,11 +18,12 @@
 		 ],
 	         "frame_mode" : "free_running",
 	         "hw_framer" : false,
+	         "tx_advance" : 100,
 		 "beacon_type" : "gold_ifft",
 		 "modulation" : "QPSK",
 		 "pilot_seq" : "lts-half",
 	         "sdr_id" : [
-		     "10.118.3.2"
+		     "10.118.2.2"
 		 ]
 	}
 }

--- a/CC/Sounder/utils.cc
+++ b/CC/Sounder/utils.cc
@@ -31,8 +31,16 @@ std::vector<size_t> Utils::strToChannels(const std::string& channel)
         channels = { 0 };
     else if (channel == "B")
         channels = { 1 };
-    else
+    else if (channel == "AB")
         channels = { 0, 1 };
+    else if (channel == "C")
+        channels = { 2 };
+    else if (channel == "D")
+        channels = { 3 };
+    else if (channel == "CD")
+        channels = { 2, 3 };
+    else if (channel == "ABCD")
+        channels = { 0, 1, 2, 3 };
     return (channels);
 }
 


### PR DESCRIPTION
- Updated example USRP config json for BS and client to include calibrated `tx_advance` value

- I would like to also extend the framework for USRPs with 4 channels (e.g., N310), so I started to modify `utils.cc` to include parsing new channel strings. Ideally, the the vectors of txgain and rxgain needs to be allocated based on the `kUseUHD` flag. However I see that the BS txgain and rxgain are initialized as fixed size arrays in `config.cc`, is there a way that we can make it resizable array? For example if `kUseUHD = true` then the arrays can be resized to include values for 4 channels (instead of 2).