### PR TITLE
Update build status URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RENEWLab
 
-[![Build Status](https://8435d1ad526d.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Ffeat-build-status)](https://8435d1ad526d.ngrok.io/job/github_public_renewlab/job/feat-build-status/)
+[![Build Status](https://0789a74e8b5e.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Ffeat-build-status)](https://0789a74e8b5e.ngrok.io/job/github_public_renewlab/job/feat-build-status/)
 
 
 # Description

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RENEWLab
 
-[![Build Status](https://8435d1ad526d.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Ffeature-ci)](https://8435d1ad526d.ngrok.io/job/github_public_renewlab/job/feature-ci/)
+[![Build Status](https://8435d1ad526d.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Fdevelop)](https://8435d1ad526d.ngrok.io/job/github_public_renewlab/job/develop/)
 
 
 # Description

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RENEWLab
 
-[![Build Status](https://8435d1ad526d.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Fdevelop)](https://8435d1ad526d.ngrok.io/job/github_public_renewlab/job/develop/)
+[![Build Status](https://8435d1ad526d.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Ffeat-build-status)](https://8435d1ad526d.ngrok.io/job/github_public_renewlab/job/feat-build-status/)
 
 
 # Description


### PR DESCRIPTION
Closes #19 

Link to #18 

Due to the Jenkins tunnel URL change #18, the build status URL needs to be updated too. Once merging to develop is done, need to merge to master, too. 