### PR TITLE
Detect bad base station nodes

### DIFF
--- a/PYTHON/IrisUtils/channel_analysis.py
+++ b/PYTHON/IrisUtils/channel_analysis.py
@@ -275,7 +275,6 @@ def find_bad_nodes(csi, corr_thresh=0.32, user=0):
 
 	"""
     userCSI = np.mean(csi[1:csi.shape[0]:,:,:,:,:], 2)
-    print(np.shape(userCSI))
     num_nodes = userCSI.shape[2]
     print(">>> Total {num_nodes} reference Iris nodes: ".format(
         num_nodes=num_nodes))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RENEWLab
 
-[![Build Status](https://4489496cb62a.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Fplot-hardcode-fix)](https://4489496cb62a.ngrok.io/job/github_public_renewlab/job/plot-hardcode-fix/)
+[![Build Status](https://4489496cb62a.ngrok.io/buildStatus/icon?job=github_public_renewlab%2Fbad-nodes)](https://4489496cb62a.ngrok.io/job/github_public_renewlab/job/bad-nodes/)
 
 
 


### PR DESCRIPTION
Add a function find_bad_nodes() to plot_hdf5(). It shall find any bad base station antennas in the hdf5 file.

Example usage case:

python3 plot_hdf5.py ../../CC/Sounder/logs/trace-2020-12-10-12-34-18_1x18x2_0_17.hdf5 --frame-start=200 --n-frames=200 --ref-user=0 --deep-inspect --corr-thresh=0.33

Example output on the terminal: Node index is 1-base. 

>>> Total 18 reference Iris nodes: 
1-corr   corr_thresh
0.145926 0.33
0.307889 0.33
0.276215 0.33
0.298751 0.33
0.278899 0.33
0.228787 0.33
0.216263 0.33
0.207952 0.33
0.204619 0.33
0.318695 0.33
0.186222 0.33
0.361901 0.33
0.286686 0.33
0.362748 0.33
0.33909 0.33
0.221429 0.33
0.207851 0.33
>>> Node 1 is a good reference.
>>> Warning! A list of bad Iris node indices: [13, 15, 16]

Closes #60 